### PR TITLE
feat(test): 增加多个组件和页面的测试用例

### DIFF
--- a/test/App.test.tsx
+++ b/test/App.test.tsx
@@ -25,7 +25,7 @@ jest.mock('../src/hooks/useSessionStorage', () => ({
 }));
 
 import React from 'react';
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { render, screen, waitFor, act, fireEvent } from '@testing-library/react';
 import App from '../src/App';
 import { useSessionStorage } from '../src/hooks/useSessionStorage';
 import { useSpeechRecognition } from '../src/hooks/useSpeechRecognition';
@@ -305,6 +305,30 @@ describe('App - 消息持久化功能', () => {
       });
     });
   });
+
+  describe('页面切换与持久化配置', () => {
+    it('切换到设置页并返回聊天页', () => {
+      const { container } = render(<App />)
+      // 点击右上角设置按钮（通过 SettingsIcon 的父按钮）
+      const settingsIcon = screen.getByTestId('SettingsIcon')
+      const settingsBtn = settingsIcon.closest('button') as HTMLButtonElement
+      fireEvent.click(settingsBtn)
+      expect(!!screen.getByText('CLI Configuration')).toBe(true)
+      // 点击返回按钮（ArrowBackIcon）
+      const backIcon = screen.getByTestId('ArrowBackIcon')
+      const backBtn = backIcon.closest('button') as HTMLButtonElement
+      fireEvent.click(backBtn)
+      // 返回到聊天页后显示标题
+      expect(!!screen.getByText('XGopilot for Desktop')).toBe(true)
+    })
+
+    it('持久化与恢复配置', () => {
+      localStorage.setItem('config', JSON.stringify({ command: 'x', baseArgs: ['--output-format', 'stream-json'], cwd: '/d', envText: 'K=V' }))
+      render(<App />)
+      expect(useSessionStorage).toHaveBeenCalled()
+      // 不抛错即可
+    })
+  })
 
   describe('VNC 状态管理', () => {
     it('应该正确初始化 VNC 状态', async () => {

--- a/test/components/MarkdownContent.more.test.tsx
+++ b/test/components/MarkdownContent.more.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { MarkdownContent } from '../../src/components/MarkdownContent'
+
+// Mock heavy ESM plugins to focus on our render paths
+jest.mock('react-markdown', () => ({ __esModule: true, default: ({ children }: any) => <div>{children}</div> }))
+jest.mock('remark-gfm', () => ({ __esModule: true, default: () => null }))
+jest.mock('rehype-highlight', () => ({ __esModule: true, default: () => null }))
+
+describe('MarkdownContent more cases', () => {
+  it('renders inline code and image alt text', () => {
+    const md = '文本 `inline` \n\n![alt](url)'
+    render(<MarkdownContent content={md} />)
+    expect(screen.getByText(/inline/)).toBeInTheDocument()
+    expect(screen.getByText(/alt/)).toBeInTheDocument()
+  })
+})
+

--- a/test/components/StreamingOutput.test.tsx
+++ b/test/components/StreamingOutput.test.tsx
@@ -45,11 +45,42 @@ describe('StreamingOutput', () => {
       }
     }
 
-    render(<StreamingOutput sessionId={'s2'} isActive={true} />)
+    const { container } = render(<StreamingOutput sessionId={'s2'} isActive={true} />)
     expect(screen.getByText(/Claude Code 执行状态/)).toBeInTheDocument()
     expect(screen.getByText(/使用工具/)).toBeInTheDocument()
     expect(screen.getByText(/工具结果/)).toBeInTheDocument()
     expect(screen.getAllByText(/警告/).length).toBeGreaterThan(0)
     expect(screen.getByText(/错误发生/)).toBeInTheDocument()
+    // Toggle collapse by clicking header
+    const header = container.querySelector('[class*=MuiBox-root]') as HTMLElement
+    header.click()
+  })
+
+  it('handles init/ready/spawn/response/raw/system/timeout stages', () => {
+    // @ts-ignore
+    (window as any).api = {
+      onClaudeStream: (handler: any) => {
+        const sessionId = 's3'
+        handler(null, { type: 'stream-start', sessionId, timestamp: new Date().toISOString(), data: { command: 'run' } })
+        handler(null, { type: 'stream-data', sessionId, timestamp: new Date().toISOString(), data: { stage: 'init', content: '🚀 初始化' } })
+        handler(null, { type: 'stream-data', sessionId, timestamp: new Date().toISOString(), data: { stage: 'ready', content: '⚡ 就绪' } })
+        handler(null, { type: 'stream-data', sessionId, timestamp: new Date().toISOString(), data: { stage: 'spawn', content: '⚡ 启动进程' } })
+        handler(null, { type: 'stream-data', sessionId, timestamp: new Date().toISOString(), data: { stage: 'response', content: '💬 回复内容' } })
+        handler(null, { type: 'stream-data', sessionId, timestamp: new Date().toISOString(), data: { stage: 'raw', content: '💭 原始输出' } })
+        handler(null, { type: 'stream-data', sessionId, timestamp: new Date().toISOString(), data: { stage: 'system', content: '⚙️ 系统消息' } })
+        handler(null, { type: 'stream-data', sessionId, timestamp: new Date().toISOString(), data: { stage: 'timeout', content: '⏱️ 超时' } })
+        handler(null, { type: 'stream-end', sessionId, timestamp: new Date().toISOString(), data: { success: true } })
+        return () => {}
+      }
+    }
+
+    render(<StreamingOutput sessionId={'s3'} isActive={true} />)
+    expect(screen.getAllByText(/初始化/).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/就绪/).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/启动进程/).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/回复内容/).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/原始输出/).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/系统消息/).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/超时/).length).toBeGreaterThan(0)
   })
 })

--- a/test/components/VncDisplay.more.test.tsx
+++ b/test/components/VncDisplay.more.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { VncDisplay } from '../../src/components/VncDisplay'
+
+describe('VncDisplay more branches', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('shows warning alert when connectionError provided', () => {
+    render(<VncDisplay url={'http://localhost:6080'} isConnected={false} connectionError={'连接失败: HTTP 500'} />)
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.getByText(/连接失败/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '重试' })).toBeInTheDocument()
+  })
+
+  it('shows connected badge after iframe load', () => {
+    render(<VncDisplay url={'http://localhost:6080'} isConnected={true} connectionError={null} />)
+    const iframe = screen.getByTitle('VNC Desktop')
+    fireEvent.load(iframe)
+    expect(screen.getByText('已连接')).toBeInTheDocument()
+  })
+})

--- a/test/components/VncPanel.more.test.tsx
+++ b/test/components/VncPanel.more.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { VncPanel } from '../../src/components/VncPanel'
+
+describe('VncPanel more branches', () => {
+  const vncStateBase = {
+    isActive: true,
+    isLoading: false,
+    url: 'http://localhost:6080',
+    error: '',
+    containerId: 'abc'
+  }
+  const vncHealth: any[] = []
+  const updateVncState = jest.fn()
+  const resetVncState = jest.fn()
+  const addMessage = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    // @ts-ignore
+    delete (window as any).api
+  })
+
+  it('sets connectionError when fetch returns non-OK', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({ ok: false, status: 500 })
+    // @ts-ignore
+    global.fetch = mockFetch
+
+    render(
+      <VncPanel
+        vncState={vncStateBase}
+        vncHealth={vncHealth}
+        updateVncState={updateVncState}
+        resetVncState={resetVncState}
+        addMessage={addMessage}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('连接失败')).toBeInTheDocument()
+    })
+  })
+
+  it('sets connectionError when fetch throws', async () => {
+    const mockFetch = jest.fn().mockRejectedValue(new Error('boom'))
+    // @ts-ignore
+    global.fetch = mockFetch
+
+    render(
+      <VncPanel
+        vncState={vncStateBase}
+        vncHealth={vncHealth}
+        updateVncState={updateVncState}
+        resetVncState={resetVncState}
+        addMessage={addMessage}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('连接失败')).toBeInTheDocument()
+    })
+  })
+
+  it('refresh triggers addMessage when active', () => {
+    // Ok fetch to mark connected
+    // @ts-ignore
+    global.fetch = jest.fn().mockResolvedValue({ ok: true })
+    render(
+      <VncPanel
+        vncState={vncStateBase}
+        vncHealth={vncHealth}
+        updateVncState={updateVncState}
+        resetVncState={resetVncState}
+        addMessage={addMessage}
+      />
+    )
+    const refreshBtn = screen.getByTitle('刷新连接')
+    fireEvent.click(refreshBtn)
+    expect(addMessage).toHaveBeenCalledWith('system', '正在刷新VNC连接...')
+  })
+})
+

--- a/test/components/VncStatus.test.tsx
+++ b/test/components/VncStatus.test.tsx
@@ -89,4 +89,16 @@ describe('VncStatus', () => {
     expect(screen.getByText('novnc:6080')).toBeInTheDocument()
     expect(screen.getByText('tools:6100')).toBeInTheDocument()
   })
+
+  it('renders error message when vncState.error present', () => {
+    render(
+      <VncStatus
+        vncState={{ ...baseState, error: '出错了' }}
+        vncHealth={[]}
+        isConnected={false}
+        connectionError={null}
+      />
+    )
+    expect(screen.getByText('出错了')).toBeInTheDocument()
+  })
 })

--- a/test/components/VncToolbar.test.tsx
+++ b/test/components/VncToolbar.test.tsx
@@ -92,6 +92,19 @@ describe('VncToolbar', () => {
     expect(screen.getByText('连接中断')).toBeInTheDocument()
   })
 
+  it('shows loading icon on start when isLoading true', () => {
+    const { getByText } = render(
+      <VncToolbar
+        vncState={{ ...baseState, isLoading: true, isActive: false }}
+        isConnected={false}
+        onStart={jest.fn()}
+        onStop={jest.fn()}
+        onRefresh={jest.fn()}
+      />
+    )
+    expect(getByText('启动中')).toBeInTheDocument()
+  })
+
   it('shows container chip when containerId present', () => {
     render(
       <VncToolbar

--- a/test/pages/chat/components/ChatInput.test.tsx
+++ b/test/pages/chat/components/ChatInput.test.tsx
@@ -48,4 +48,17 @@ describe('ChatInput', () => {
     fireEvent.click(switchEl)
     expect(baseProps.onToggleVnc).toHaveBeenCalled()
   })
+
+  it('shows voice error and listening UI, toggles stop', () => {
+    const props = { ...baseProps, voiceError: '错误', isListening: true }
+    render(<ChatInput {...props} />)
+    expect(screen.getByText('错误')).toBeInTheDocument()
+    expect(screen.getByText('正在录音,请说话...')).toBeInTheDocument()
+    const micButton = screen.getByRole('button', { name: /点击停止录音/ })
+    fireEvent.click(micButton)
+    expect(baseProps.onStopVoice).toHaveBeenCalled()
+    // Send button should be disabled while listening
+    const sendButton = screen.getByRole('button', { name: '发送消息 (Enter)' })
+    expect(sendButton).toBeDisabled()
+  })
 })

--- a/test/pages/chat/components/SessionSidebar.test.tsx
+++ b/test/pages/chat/components/SessionSidebar.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { SessionSidebar } from '../../../../src/pages/chat/components/SessionSidebar'
+
+describe('SessionSidebar', () => {
+  const sessions = [
+    { id: 's1', title: '短标题', createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(), messages: [] },
+    { id: 's2', title: '很长很长很长很长很长很长很长很长很长很长的标题', createdAt: new Date().toISOString(), updatedAt: new Date(Date.now() - 24*3600*1000).toISOString(), messages: [] },
+  ]
+
+  const props = {
+    open: true,
+    onClose: jest.fn(),
+    sessions: sessions as any,
+    activeSessionId: 's1',
+    onSessionSelect: jest.fn(),
+    onNewSession: jest.fn(),
+  }
+
+  beforeEach(() => jest.clearAllMocks())
+
+  it('renders header and new session button', () => {
+    render(<SessionSidebar {...props} />)
+    expect(screen.getByText('会话历史')).toBeInTheDocument()
+    expect(screen.getByText('新建会话')).toBeInTheDocument()
+  })
+
+  it('handles close and new session actions', () => {
+    render(<SessionSidebar {...props} />)
+    fireEvent.click(screen.getByRole('button', { name: '' })) // Close IconButton has no accessible name
+    expect(props.onClose).toHaveBeenCalled()
+    fireEvent.click(screen.getByText('新建会话'))
+    expect(props.onNewSession).toHaveBeenCalled()
+  })
+
+  it('renders sessions and selects active', () => {
+    render(<SessionSidebar {...props} />)
+    expect(screen.getByText('短标题')).toBeInTheDocument()
+    // Long title should be truncated (presence suffices)
+    expect(screen.getByText(/很长很长/)).toBeInTheDocument()
+  })
+
+  it('formats dates as 今天/昨天/几天前', () => {
+    const now = new Date()
+    const sessions = [
+      { id: 's1', title: '今天的', createdAt: now.toISOString(), updatedAt: now.toISOString(), messages: [] },
+      { id: 's2', title: '昨天的', createdAt: now.toISOString(), updatedAt: new Date(now.getTime() - 24*3600*1000).toISOString(), messages: [] },
+      { id: 's3', title: '三天前', createdAt: now.toISOString(), updatedAt: new Date(now.getTime() - 3*24*3600*1000).toISOString(), messages: [] },
+    ]
+    const p = { ...props, sessions: sessions as any }
+    render(<SessionSidebar {...p} />)
+    expect(screen.getByText('今天')).toBeInTheDocument()
+    expect(screen.getByText('昨天')).toBeInTheDocument()
+    expect(screen.getByText('3天前')).toBeInTheDocument()
+  })
+
+  it('selects session on click', () => {
+    render(<SessionSidebar {...props} />)
+    fireEvent.click(screen.getByText('短标题'))
+    expect(props.onSessionSelect).toHaveBeenCalledWith('s1')
+  })
+})

--- a/test/prompts/prompt-builder-extra.test.ts
+++ b/test/prompts/prompt-builder-extra.test.ts
@@ -29,5 +29,14 @@ describe('PromptBuilder extras', () => {
     expect(end).toHaveBeenCalled()
     group.mockRestore(); log.mockRestore(); end.mockRestore()
   })
-})
 
+  it('createPromptBuilderFromEnv builds without platform gracefully', () => {
+    const original = (global as any).navigator
+    ;(global as any).navigator = undefined
+    const mod = require('../../src/prompts/prompt-builder')
+    const pb = mod.createPromptBuilderFromEnv(true, { vnc: 5900, web: 6080 }, 'CI')
+    const prompt = pb.build()
+    expect(prompt).toContain('虚拟桌面') // basic content ensured
+    ;(global as any).navigator = original
+  })
+})


### PR DESCRIPTION
新增了对 App 组件的页面切换与配置持久化功能的测试，补充了 MarkdownContent、StreamingOutput、VncDisplay、VncPanel、VncStatus、VncToolbar、ChatInput 和 SessionSidebar 等组件的更多测试场景。同时增强了对 VNC 相关状态、错误处理、UI 交互及语音输入提示的覆盖。此外，还完善了 prompt builder 在无平台环境下的容错测试。